### PR TITLE
Fix deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,19 @@ addons:
   apt:
     update: true
     packages:
-      - texlive-latex-extra
-      - texlive-fonts-recommended
-
+    - texlive-latex-extra
+    - texlive-fonts-recommended
 script:
-  - make paper.pdf
-
+- make paper.pdf
 before_deploy:
-  - git config --local user.name "Evaluating Adversarial Robustness Bot"
-  - git config --local user.email "evaluating-adversarial-robustness-bot@users.noreply.github.com"
-  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-  - git tag $TRAVIS_TAG
+- git config --local user.name "Evaluating Adversarial Robustness Bot"
+- git config --local user.email "evaluating-adversarial-robustness-bot@users.noreply.github.com"
+- export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+- git tag $TRAVIS_TAG
 deploy:
   provider: releases
   api_key:
-    secure: gnLFlIa0FRulN6qtCSdyXwQBGyXgBxKDG8dELLGTSZfvo1Ui5S82PBCs3SSdno1mKK/DJ9LjNrw1cfppIdTLTpR1L5IJuNA0Lu9hWmSYBNRQU1PjR/pURHLFoI9nvQhWEdR1jt7IILm9LILkUp/37Qjm9BuUsiMLvcWdzZ32GvQThLOSy/0l+/fa3tl8GqZdXl/TS+btGOFdQulxBRDg5H9jRarz7FOaHguxkuNaWqG40iu3FU2azbS+yIysdk1QAdOjq2x2LA5YwW3m00KYJp4eMgTTOjTxSX3V9YrlbOFTeNO3dl4pS3/elLpFNDEf8TZJ8FLVm+ZO2hcc1r/jMYxmiYBvjnUEbKn5WVw4oPVZ9iN9b3TQ6NNMLt8xUN4vpfb9W0YFllknz349GxsieuzaGDi/DHdTi2UGsdxRuNM/4czre5ovVayu5WijaqChq97rsWYYCBBLC1dkWaBs9aNi9UoHfvE8UlglQdTtyjKBFJXyOOdmsthq27c8I+d868oE1z0tCVTcB5FFBAHjSV1PNgZDO0JkwUkMvrvdorEW/3LFHtx+9sx3eZG0c7Lys/2dzBTGX1UOokEelt7newka5SDC6cNJgwYP2Ifqji6wCpFr3SQ+tOnMCnuoz47T7rKHT+DemXRop7bJnMGhH8XMFhGLntIbPWNXo2InmLU=
+    secure: RxvWCEfK/lX2uX6KcoaKlr4j8VyFD9S223GRTaMB6coktR8CQuiXZUhV30MEMdFBGKl+hSb0CXlqm7dQt4shLXoemrWpMHbpqAyFW0zB3oZuO9jQeCfd4xj74xte5CyLihGEqSdKUWOW7h38Cm/No7Mu04iLAEg2IgV9Tn+n7RKKNKV0o06h+BDxyTZQQTXBgjo2GLOea1fIbSDwl2jFDbMd9eVc6GqsmHIu44WynCPjAlg0M/9e25/G3XwSgCfXwhyBefTGnBbB61Aoh0YfeAytTuVTctchQZ8b0C8aT817nKVCCDQL6mu1GaxhnAigWW8fgCJmtPwkpfydtcdk6mbub9zAt9rG+a5wV/fCSyUIw27rn4Ps6YqbrzzBRRReXgBS5CzyIh6Qc2D/e3XG82WAYN4GzFnWRVwx0WacWjJdTSrga4zItrnHh0yB9hZoSrI0clQwIS2pCl9bamjRICr7lQCUYvtAJbU1Ay2ldTjZGpqO64ipvH8gD80sW72eqwQ4hqYrNMjqjx+kQnu6vheuy/c0OJ6ahGsQTCli4zou/vbZjCRRFaCJXPhi54obB7KjT9P/U/r84RBY8ZowDQdwX2aoIrkxs+t8FZ4KPddcxgQuEf1XBUyvQFKNKBJ+f/yA9LFRRgUQ13JVd5ZZ1U+rFCW95fjoUYkdxaBiLx4=
   file: paper.pdf
-  skip_cleanup: true
+  on:
+    repo: evaluating-adversarial-robustness/adv-eval-paper


### PR DESCRIPTION
For some reason, the auto-deploy of the compiled paper seems to be [broken](https://travis-ci.org/evaluating-adversarial-robustness/adv-eval-paper/builds/531828676) (with "bad credentials").

This used to work at [some point](https://travis-ci.org/evaluating-adversarial-robustness/adv-eval-paper/builds/496702109), and nothing has changed with the Travis CI config since then, so I'm not really sure why it doesn't work anymore.

Maybe re-creating the secret will fix it?

(Also, I'm not sure how to test this without actually pushing to master.)